### PR TITLE
Custom db auto setup

### DIFF
--- a/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -2,6 +2,9 @@ package org.testcontainers.containers;
 
 import org.testcontainers.containers.wait.HostPortWaitStrategy;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -15,6 +18,9 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     public static final Integer MS_SQL_SERVER_PORT = 1433;
     private String username = "SA";
     private String password = "A_Str0ng_Required_Password";
+    private String collation;
+    private String databaseName;
+    private boolean isCustomDbCreated;
 
     public MSSQLServerContainer() {
         this(IMAGE + ":latest");
@@ -37,6 +43,7 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
         addExposedPort(MS_SQL_SERVER_PORT);
         addEnv("ACCEPT_EULA", "Y");
         addEnv("SA_PASSWORD", password);
+
     }
 
     @Override
@@ -46,7 +53,13 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
 
     @Override
     public String getJdbcUrl() {
-        return "jdbc:sqlserver://" + getContainerIpAddress() + ":" + getMappedPort(MS_SQL_SERVER_PORT);
+        StringBuilder sb = new StringBuilder("jdbc:sqlserver://" + getContainerIpAddress() + ":" + getMappedPort(MS_SQL_SERVER_PORT));
+
+        if (isCustomDbCreated) {
+            sb.append(";databaseName=").append(databaseName);
+        }
+
+        return sb.toString();
     }
 
     @Override
@@ -67,5 +80,45 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     @Override
     protected void waitUntilContainerStarted() {
         getWaitStrategy().waitUntilReady(this);
+    }
+
+    @Override
+    public SELF withDatabaseName(final String databaseName) {
+        this.databaseName = databaseName;
+        return self();
+    }
+
+    public SELF withCollation(final String collation) {
+        this.collation = collation;
+        return self();
+    }
+
+
+    @Override
+    public void start() {
+        super.start();
+
+        if (this.databaseName != null) {
+            createCustomDataBase();
+        }
+    }
+
+    private void createCustomDataBase() {
+        try (Connection conn = createConnection("");
+             Statement stmt = conn.createStatement()
+        ) {
+            StringBuilder sqlBuilder = new StringBuilder("CREATE DATABASE ")
+                    .append(databaseName);
+
+            if (this.collation != null) {
+                sqlBuilder.append(" COLLATE ").append(collation);
+            }
+
+            stmt.executeUpdate(sqlBuilder.toString());
+            conn.commit();
+            isCustomDbCreated = true;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/org/testcontainers/junit/CustomDbMSSQLServerTest.java
+++ b/src/test/java/org/testcontainers/junit/CustomDbMSSQLServerTest.java
@@ -1,0 +1,55 @@
+package org.testcontainers.junit;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.MSSQLServerContainer;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.*;
+
+public class CustomDbMSSQLServerTest {
+
+    private static final String DATABASE_NAME = "custom";
+    private static final String COLLATION = "Cyrillic_General_CI_AS";
+
+    @Rule
+    public MSSQLServerContainer mssqlServer = new MSSQLServerContainer()
+            .withDatabaseName(DATABASE_NAME)
+            .withCollation(COLLATION);
+
+
+    @Test
+    public void testAutoSetUpCustomDb() throws SQLException {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(mssqlServer.getJdbcUrl());
+        hikariConfig.setUsername(mssqlServer.getUsername());
+        hikariConfig.setPassword(mssqlServer.getPassword());
+
+        try (HikariDataSource ds = new HikariDataSource(hikariConfig)) {
+
+            Statement statement = ds.getConnection().createStatement();
+            ResultSet rs = statement.executeQuery("SELECT DB_NAME() AS dbName");
+
+            rs.next();
+            assertEquals(
+                    "Current database SELECT query succeeds",
+                    DATABASE_NAME,
+                    rs.getString(1)
+            );
+
+            PreparedStatement preparedStatement = ds.getConnection()
+                    .prepareStatement("SELECT collation_name FROM sys.databases WHERE name = ?");
+
+            preparedStatement.setString(1, DATABASE_NAME);
+            rs = preparedStatement.executeQuery();
+            rs.next();
+            assertEquals("", COLLATION, rs.getString(1));
+        }
+    }
+}

--- a/src/test/java/org/testcontainers/junit/CustomDbMSSQLServerTest.java
+++ b/src/test/java/org/testcontainers/junit/CustomDbMSSQLServerTest.java
@@ -49,7 +49,11 @@ public class CustomDbMSSQLServerTest {
             preparedStatement.setString(1, DATABASE_NAME);
             rs = preparedStatement.executeQuery();
             rs.next();
-            assertEquals("", COLLATION, rs.getString(1));
+            assertEquals(
+                    "Current collation SELECT query succeeds",
+                    COLLATION,
+                    rs.getString(1)
+            );
         }
     }
 }


### PR DESCRIPTION
Hi there.

We use testcontainers for the testing of our own db tool. And we found that environment variable MSSQL_COLLATION can cause deadlocks on MsSql Server level. Therefore, I implemented the ability to run a container with the desired value of collation for specified database. 

There is no  possibility to do it without of creation of new database. 

Let me know, if I'm not architecturally right. Our product needs this functionality (even if it's a different version).