### PR TITLE
Use default JdbcDatabaseContainer.waitUntilContainerStarted

### DIFF
--- a/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -1,11 +1,5 @@
 package org.testcontainers.containers;
 
-import org.testcontainers.containers.wait.HostPortWaitStrategy;
-
-import java.time.Duration;
-
-import static java.time.temporal.ChronoUnit.SECONDS;
-
 /**
  * @author Stefan Hufschmidt
  */
@@ -22,8 +16,6 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
 
     public MSSQLServerContainer(final String dockerImageName) {
         super(dockerImageName);
-        this.waitStrategy = new HostPortWaitStrategy()
-                .withStartupTimeout(Duration.of(60, SECONDS));
     }
 
     @Override
@@ -62,10 +54,5 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     @Override
     public String getTestQueryString() {
         return "SELECT 1";
-    }
-
-    @Override
-    protected void waitUntilContainerStarted() {
-        getWaitStrategy().waitUntilReady(this);
     }
 }


### PR DESCRIPTION
- the current solution ignores the JDBC connection check and this makes tests using MSSQLServerContainer flaky since the database might not be ready at the moment when the connection check to the port already succeeds.
- this change removes the custom solution in MSSQLServerContainer and simply uses the default implementation from the super class (JdbcDatabaseContainer.waitUntilContainerStarted).