### PR TITLE
Implemented auto-setup of database specified by withDatabaseName and …

### DIFF
--- a/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -2,6 +2,7 @@ package org.testcontainers.containers;
 
 import org.testcontainers.containers.wait.HostPortWaitStrategy;
 
+import java.io.IOException;
 import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -15,6 +16,8 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     public static final Integer MS_SQL_SERVER_PORT = 1433;
     private String username = "SA";
     private String password = "A_Str0ng_Required_Password";
+    private String dbName;
+    private String collation;
 
     public MSSQLServerContainer() {
         this(IMAGE + ":latest");
@@ -67,5 +70,60 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     @Override
     protected void waitUntilContainerStarted() {
         getWaitStrategy().waitUntilReady(this);
+    }
+
+    @Override
+    public SELF withDatabaseName(final String dbName) {
+        this.dbName = dbName;
+        return self();
+    }
+
+    /**
+     * Sets the collation for a database which is specified by {@link #withDatabaseName(String)}.
+     * The collation will only be set if a database has been specified by {@link #withDatabaseName(String)} before the container start.
+     * It will only be set at the one database which will be created.
+     *
+     * @param collation the collation to set at the database
+     * @return self
+     */
+    public SELF withCollation(final String collation) {
+        this.collation = collation;
+        return self();
+    }
+
+    @Override
+    public void start() {
+        super.start();
+
+        if (dbName != null) {
+            createDatabase();
+        }
+    }
+
+    /**
+     * Creates a database in MS SQL Server by using the command line tool 'sqlcmd' inside the MS SQL Server container.
+     * The database will get the name specified by {@link #withDatabaseName(String)}.
+     * If a collation is set by {@link #withCollation(String)}, it will be applied to the database which will be created.
+     */
+    private void createDatabase() {
+        StringBuilder createQueryBuilder = new StringBuilder("CREATE DATABASE ")
+                .append(dbName);
+
+        if (collation != null) {
+            createQueryBuilder.append(" COLLATE ")
+                    .append(collation);
+        }
+
+        try {
+            execInContainer(
+                    "/opt/mssql-tools/bin/sqlcmd",
+                    "-S", "localhost",
+                    "-U", username,
+                    "-P", password,
+                    "-Q", createQueryBuilder.toString()
+            );
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/org/testcontainers/junit/MSSQLServerWithDatabaseTest.java
+++ b/src/test/java/org/testcontainers/junit/MSSQLServerWithDatabaseTest.java
@@ -1,0 +1,83 @@
+package org.testcontainers.junit;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MSSQLServerContainer;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class MSSQLServerWithDatabaseTest {
+
+    @Test
+    public void checkDatabaseExistsOnStartup() throws SQLException {
+        // given: a database name
+        final String databaseName = "foo";
+
+        // given: a MSSQLServerContainer with specified database
+        JdbcDatabaseContainer mssqlServerContainer = new MSSQLServerContainer()
+                .withDatabaseName(databaseName);
+        mssqlServerContainer.start();
+
+        // when: checking if database exists
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(mssqlServerContainer.getJdbcUrl());
+        hikariConfig.setUsername(mssqlServerContainer.getUsername());
+        hikariConfig.setPassword(mssqlServerContainer.getPassword());
+
+        HikariDataSource ds = new HikariDataSource(hikariConfig);
+        PreparedStatement pst = ds.getConnection().prepareStatement("SELECT name FROM master.sys.databases WHERE name = ?");
+        pst.setString(1, databaseName);
+        ResultSet resultSet = pst.executeQuery();
+
+        // then: result should contain the database name
+        Assert.assertTrue(
+                "ResultSet is empty and does not contain the required database name!",
+                resultSet.next()
+        );
+        Assert.assertEquals(
+                "Returned database name does not match the one which is expected!",
+                resultSet.getString("name"),
+                databaseName
+        );
+    }
+
+    @Test
+    public void checkCustomDatabaseWithCollation() throws SQLException {
+        // given: a database name
+        final String databaseName = "foo";
+        final String collation = "Latin1_General_100_CS_AS_SC";
+
+        // given: a MSSQLServerContainer with specified database
+        JdbcDatabaseContainer mssqlServerContainer = new MSSQLServerContainer()
+                .withDatabaseName(databaseName)
+                .withCollation(collation);
+        mssqlServerContainer.start();
+
+        // when: checking if database exists
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(mssqlServerContainer.getJdbcUrl());
+        hikariConfig.setUsername(mssqlServerContainer.getUsername());
+        hikariConfig.setPassword(mssqlServerContainer.getPassword());
+
+        HikariDataSource ds = new HikariDataSource(hikariConfig);
+        PreparedStatement pst = ds.getConnection().prepareStatement("SELECT collation_name FROM sys.databases WHERE name = ?");
+        pst.setString(1, databaseName);
+        ResultSet resultSet = pst.executeQuery();
+
+        // then: result should contain the database name
+        Assert.assertTrue(
+                "ResultSet is empty and the required database has not been created!",
+                resultSet.next()
+        );
+        Assert.assertEquals(
+                "Returned collation does not match the one which is expected!",
+                resultSet.getString("collation_name"),
+                collation
+        );
+    }
+}

--- a/src/test/java/org/testcontainers/junit/SimpleMSSQLServerTest.java
+++ b/src/test/java/org/testcontainers/junit/SimpleMSSQLServerTest.java
@@ -2,10 +2,10 @@ package org.testcontainers.junit;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.MSSQLServerContainer;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -17,20 +17,18 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
  */
 public class SimpleMSSQLServerTest {
 
-    @Rule
-    public MSSQLServerContainer mssqlServer = new MSSQLServerContainer();
-
     @Test
     public void testSimple() throws SQLException {
+        MSSQLServerContainer mssqlServer = new MSSQLServerContainer();
+        mssqlServer.start();
         HikariConfig hikariConfig = new HikariConfig();
         hikariConfig.setJdbcUrl(mssqlServer.getJdbcUrl());
         hikariConfig.setUsername(mssqlServer.getUsername());
         hikariConfig.setPassword(mssqlServer.getPassword());
 
         HikariDataSource ds = new HikariDataSource(hikariConfig);
-        Statement statement = ds.getConnection().createStatement();
-        statement.execute("SELECT 1");
-        ResultSet resultSet = statement.getResultSet();
+        PreparedStatement statement = ds.getConnection().prepareStatement("SELECT 1");
+        ResultSet resultSet = statement.executeQuery();
 
         resultSet.next();
         int resultSetInt = resultSet.getInt(1);
@@ -39,6 +37,8 @@ public class SimpleMSSQLServerTest {
 
     @Test
     public void testSetupDatabase() throws SQLException {
+        MSSQLServerContainer mssqlServer = new MSSQLServerContainer();
+        mssqlServer.start();
         HikariConfig hikariConfig = new HikariConfig();
         hikariConfig.setJdbcUrl(mssqlServer.getJdbcUrl());
         hikariConfig.setUsername(mssqlServer.getUsername());


### PR DESCRIPTION
...withCollation

I've implemented the requested changes of pull-request "Custom db auto setup #4" but with using the native command line tool inside the MS SQL Server container to set up everything. So the MS SQL Server driver is not needed in the module.